### PR TITLE
Add endpoint attribute to ReviewScaper::Client class

### DIFF
--- a/lib/datashake-ruby-sdk/review_scraper/client.rb
+++ b/lib/datashake-ruby-sdk/review_scraper/client.rb
@@ -7,8 +7,9 @@ module Datashake
     class Client
       BASE_URL = "https://app.datashake.com"
 
-      def initialize(token:, adapter: Faraday.default_adapter, timeout: 30, open_timeout: 30)
+      def initialize(token:, adapter: Faraday.default_adapter, endpoint: nil, timeout: 30, open_timeout: 30)
         @token = token
+        @base_url = endpoint || BASE_URL
         @adapter = adapter
         @timeout = timeout
         @open_timeout = open_timeout
@@ -17,7 +18,7 @@ module Datashake
       def connection
         @connection ||= Faraday.new do |conn|
           conn.headers = {"spiderman-token" => token}
-          conn.url_prefix = BASE_URL
+          conn.url_prefix = base_url
           conn.request(:json)
           conn.response(:json, content_type: "application/json")
           conn.options.timeout = timeout
@@ -60,7 +61,7 @@ module Datashake
 
       private
 
-      attr_reader :token, :adapter, :timeout, :open_timeout
+      attr_reader :token, :adapter, :timeout, :open_timeout, :base_url
     end
   end
 end

--- a/lib/datashake-ruby-sdk/version.rb
+++ b/lib/datashake-ruby-sdk/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Datashake
-  VERSION = "1.2.1"
+  VERSION = "1.3.0"
 end

--- a/spec/datashake-ruby-sdk/review_scraper/client_spec.rb
+++ b/spec/datashake-ruby-sdk/review_scraper/client_spec.rb
@@ -3,7 +3,25 @@
 require "spec_helper"
 
 RSpec.describe Datashake::ReviewScraper::Client do
-  subject { described_class.new(token: "abc") }
+  subject { described_class.new(token: "abc", endpoint: endpoint) }
+
+  let(:endpoint) { nil }
+
+  describe "#connection" do
+    context "when endpoint is provided" do
+      let(:endpoint) { "https://custom.endpoint.com" }
+
+      it "uses the provided endpoint as the base_url" do
+        expect(subject.connection.url_prefix.to_s).to eq("#{endpoint}/")
+      end
+    end
+
+    context "when endpoint is not provided" do
+      it "uses the default BASE_URL as the base_url" do
+        expect(subject.connection.url_prefix.to_s).to eq("#{Datashake::ReviewScraper::Client::BASE_URL}/")
+      end
+    end
+  end
 
   describe "#profiles" do
     specify do


### PR DESCRIPTION
enhance datashake-ruby-sdk-api-url-flexibility to allow for another host Instead of `app.datashake.com`